### PR TITLE
Bugfix variable selector

### DIFF
--- a/packages/ui/src/views/inputs/ArrayInputParameters.js
+++ b/packages/ui/src/views/inputs/ArrayInputParameters.js
@@ -390,6 +390,7 @@ const ArrayInputParameters = ({
                                     onBlur={(e) => {
                                         const inputValue = e.target.value;
                                         onInputBlur(inputValue, inputName, values, index);
+                                        onMouseUp(e, inputName, index);
                                     }}
                                     onChange={(e) => {
                                         const inputValue = e.target.value;

--- a/packages/ui/src/views/inputs/InputParameters.js
+++ b/packages/ui/src/views/inputs/InputParameters.js
@@ -403,6 +403,7 @@ const InputParameters = ({
                                         onBlur={e => {
                                             handleBlur(e);
                                             onChanged(values);
+                                            onMouseUp(e, inputName);
                                         }}
                                         onMouseUp={(e) => onMouseUp(e, inputName)}
                                         onChange={handleChange}


### PR DESCRIPTION
Bug: selecting variable will cause initial input field to clear.
Expected: selecting variable will still remain the initial input.
