### PR TITLE
Fix code input string parse error

### DIFF
--- a/packages/server/.env
+++ b/packages/server/.env
@@ -1,0 +1,6 @@
+PORT=3000
+PASSPHRASE=MYPASSPHRASE
+ENABLE_TUNNEL=true
+MONGO_HOST=localhost
+# MONGO_URL=mongodb+srv://<user>:<password>@cluster0.qskldy2.mongodb.net/outerbridge?retryWrites=true&w=majority
+# EXECUTION_TIMEOUT=5000

--- a/packages/server/src/utils/index.ts
+++ b/packages/server/src/utils/index.ts
@@ -283,7 +283,7 @@ export const constructGraphsAndGetStartingNodes = (res: Response, reactFlowNodes
  * @param {IReactFlowNode[]} reactFlowNodes
  * @returns {string}
  */
-export const getVariableValue = (paramValue: string, reactFlowNodes: IReactFlowNode[]): string => {
+export const getVariableValue = (paramValue: string, reactFlowNodes: IReactFlowNode[], key: string): string => {
     let returnVal = paramValue
     const variableStack = []
     const variableDict = {} as IVariableDict
@@ -310,9 +310,11 @@ export const getVariableValue = (paramValue: string, reactFlowNodes: IReactFlowN
 
             const executedNode = reactFlowNodes.find((nd) => nd.id === variableNodeId)
             if (executedNode) {
-                const resolvedVariablePath = getVariableValue(variablePath, reactFlowNodes)
-                const variableValue = lodash.get(executedNode.data, resolvedVariablePath, '')
-                variableDict[`{{${variableFullPath}}}`] = variableValue || ''
+                const resolvedVariablePath = getVariableValue(variablePath, reactFlowNodes, key)
+                const variableValue = lodash.get(executedNode.data, resolvedVariablePath)
+                variableDict[`{{${variableFullPath}}}`] = variableValue
+                // For instance: const var1 = "some var"
+                if (key === 'code' && typeof variableValue === 'string') variableDict[`{{${variableFullPath}}}`] = `"${variableValue}"`
             }
             variableStack.pop()
         }
@@ -345,13 +347,13 @@ export const resolveVariables = (reactFlowNodeData: INodeData, reactFlowNodes: I
             const paramValue = paramsObj[key]
 
             if (typeof paramValue === 'string') {
-                const resolvedValue = getVariableValue(paramValue, reactFlowNodes)
+                const resolvedValue = getVariableValue(paramValue, reactFlowNodes, key)
                 paramsObj[key] = resolvedValue
             }
 
             if (typeof paramValue === 'number') {
                 const paramValueStr = paramValue.toString()
-                const resolvedValue = getVariableValue(paramValueStr, reactFlowNodes)
+                const resolvedValue = getVariableValue(paramValueStr, reactFlowNodes, key)
                 paramsObj[key] = resolvedValue
             }
 

--- a/packages/ui/src/views/canvas/index.js
+++ b/packages/ui/src/views/canvas/index.js
@@ -690,7 +690,10 @@ const Canvas = () => {
     useEffect(() => {
         function handlePaste(e) {
             const pasteData = e.clipboardData.getData('text')
-            handleLoadWorkflow(pasteData)
+            //TODO: prevent paste event when input focused, temporary fix: catch workflow syntax
+            if (pasteData.includes('{"nodes":[') && pasteData.includes('],"edges":[')) {
+                handleLoadWorkflow(pasteData)
+            }
         }
 
         window.addEventListener('paste', handlePaste)


### PR DESCRIPTION
When variable (i.e: `{{node[0].data.var}}`) is used on code parameter of NodeJS node, it is not parsed correctly.

For example:
`const example = {{node[0].data.var}}`

Parsed value:
`const example = some var`

Expected:
`const example = "some var"`